### PR TITLE
Fix bug when turning blindfold on while GPU is off

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Blindfold
-Run instead of the GPU plugin to only render your character and nothing else.
+
+This plugin allows hiding everything except the player character when used
+in combination with a GPU plugin such as RuneLite's GPU plugin or 117 HD.

--- a/src/main/java/com/stevenwaterman/blindfold/BlindfoldPlugin.java
+++ b/src/main/java/com/stevenwaterman/blindfold/BlindfoldPlugin.java
@@ -74,7 +74,11 @@ public class BlindfoldPlugin extends Plugin implements DrawCallbacks
 	protected void startUp()
 	{
 		overlayManager.add(overlay);
-		clientThread.invokeLater(this::interceptDrawCalls);
+		clientThread.invokeLater(() -> {
+			// We want to specifically ignore the return value here, so RuneLite doesn't
+			// interpret this as something that needs to be retried until it returns true
+			interceptDrawCalls();
+		});
 	}
 
 	@Override


### PR DESCRIPTION
I overlooked `ClientThread#invokeLater`'s boolean return value feature, where it will continuously invoke the callback until it returns true. In an earlier version, `interceptDrawCalls` had no return value, so this was a rather hidden bug.