### PR TITLE
Remove drawFace methods

### DIFF
--- a/src/main/java/com/stevenwaterman/blindfold/BlindfoldPlugin.java
+++ b/src/main/java/com/stevenwaterman/blindfold/BlindfoldPlugin.java
@@ -296,15 +296,6 @@ public class BlindfoldPlugin extends Plugin implements DrawCallbacks
 	}
 
 	@Override
-	public boolean drawFace(Model model, int face)
-	{
-		// Probably a no-op, but pass it on anyway
-		if (interceptedDrawCallbacks != null)
-			return interceptedDrawCallbacks.drawFace(model, face);
-		return false;
-	}
-
-	@Override
 	public void draw(
 		Renderable renderable, int orientation,
 		int pitchSin, int pitchCos, int yawSin, int yawCos,

--- a/src/main/java/com/stevenwaterman/blindfold/DisableRenderCallbacks.java
+++ b/src/main/java/com/stevenwaterman/blindfold/DisableRenderCallbacks.java
@@ -35,12 +35,6 @@ public class DisableRenderCallbacks implements DrawCallbacks
 	}
 
 	@Override
-	public boolean drawFace(Model model, int face)
-	{
-		return false;
-	}
-
-	@Override
 	public void drawScene(int cameraX, int cameraY, int cameraZ, int cameraPitch, int cameraYaw, int plane)
 	{
 


### PR DESCRIPTION
The drawFace callback has been removed in RuneLite 1.10.11.2.