### PR TITLE
Fix issue with switching config profiles

### DIFF
--- a/src/main/java/com/stevenwaterman/blindfold/BlindfoldPlugin.java
+++ b/src/main/java/com/stevenwaterman/blindfold/BlindfoldPlugin.java
@@ -162,6 +162,11 @@ public class BlindfoldPlugin extends Plugin implements DrawCallbacks
 	{
 		assert client.isClientThread();
 
+		// Don't attempt to intercept draw calls during loading, since switching config profiles
+		// may lead to multiple plugins modifying draw callbacks rapidly
+		if (client.getGameState() == GameState.LOADING)
+			return false;
+
 		// We only care about replacing draw callbacks while a GPU plugin is active
 		if (!client.isGpu())
 			return false;


### PR DESCRIPTION
An upcoming RuneLite update should make switching between config profiles with different GPU plugins more robust, but the blindfold plugin still causes issues. The most straight-forward fix is to avoid replacing draw callbacks while the client is loading, to avoid accidentally interfering with rapidly changing draw callbacks.