### PR TITLE
Fix compatibility with floating point camera

### DIFF
--- a/src/main/java/com/stevenwaterman/blindfold/BlindfoldPlugin.java
+++ b/src/main/java/com/stevenwaterman/blindfold/BlindfoldPlugin.java
@@ -185,6 +185,13 @@ public class BlindfoldPlugin extends Plugin implements DrawCallbacks
 	}
 
 	@Override
+	public void drawScene(double cameraX, double cameraY, double cameraZ, double cameraPitch, double cameraYaw, int plane)
+	{
+		if (interceptedDrawCallbacks != null)
+			interceptedDrawCallbacks.drawScene(cameraX, cameraY, cameraZ, cameraPitch, cameraYaw, plane);
+	}
+
+	@Override
 	public void drawScene(int cameraX, int cameraY, int cameraZ, int cameraPitch, int cameraYaw, int plane)
 	{
 		if (interceptedDrawCallbacks != null)


### PR DESCRIPTION
Fixes compatibility with the following commit https://github.com/runelite/runelite/commit/d8525601190c7aedd8810525b4f9d553e4df9c70.

This was causing the GPU plugin to break rather horribly:
![image](https://github.com/stevenwaterman/runelite-plugins/assets/831317/f87e3105-c4ff-4547-af88-6c20773f9845)
![image](https://github.com/stevenwaterman/runelite-plugins/assets/831317/50d4e624-27ef-4127-825f-4f16ce19b421)
